### PR TITLE
caso de test habilitación y deshablitación de boton validar renaper

### DIFF
--- a/cypress/integration/core/mpi/mpi.spec.js
+++ b/cypress/integration/core/mpi/mpi.spec.js
@@ -471,4 +471,32 @@ DEJAR COMENTADO HASTA QUE SE SUBA LA ACTUALIZACION DE MPI 2
 
 //     });
 
+//     it('Habilitar boton validar renaper', () => {
+
+//         cy.server();
+//         //Rutas para control
+//         cy.route('GET', '**api/core/mpi/pacientes**').as('habilitarBotonRenaper');
+
+//         // Buscador
+//         cy.get('plex-text[name="buscador"] input').first().type('36593546').should('have.value', '36593546');
+//         cy.wait('@habilitarBotonRenaper').then((xhr) => {
+//             expect(xhr.status).to.be.eq(200);
+//         });
+
+//         cy.get('div').contains('36593546').click();
+
+//         cy.get('button[class="btn btn-info  waves-effect"]').should('have.prop', 'disabled', false);
+
+//         cy.get('plex-int[name="documento"] input').clear();
+
+//         cy.get('button[class="btn btn-info  waves-effect"]').should('have.prop', 'disabled', true);
+
+//         cy.get('plex-int[name="documento"] input').type('36593546').should('have.value', '36593546');
+
+//         cy.get('button[class="btn btn-info  waves-effect"]').should('have.prop', 'disabled', false);
+
+//         cy.swal('confirm');
+
+//     });
+
 // })


### PR DESCRIPTION
Caso de test habilitación y deshablitación de botón validar renaper.
[Ref. a issue en app #1234](https://github.com/andes/app/issues/1234)
Issue resuelto branches:

- API: [v4.5.0](https://github.com/andes/app/pull/1171)
- APP: [fixesMpi](https://github.com/andes/app/pull/1172)