### PR TITLE
RUP: test de actividades no nominalizadas

### DIFF
--- a/cypress/fixtures/agenda-no-nominalizada.json
+++ b/cypress/fixtures/agenda-no-nominalizada.json
@@ -1,0 +1,81 @@
+{
+    "nominalizada": false,
+    "estado": "publicada",
+    "dinamica": false,
+    "profesionales" : [ 
+        {
+            "_id" : "5ba38d407d5bf92c0bbb2d43",
+            "nombre" : "Marco",
+            "apellido" : "Santarelli "
+        }
+    ],
+    "bloques": [{
+        "indice": 0,
+        "cantidadTurnos": 0,
+        "horaInicio": "2019-05-14T11:00:00.000Z",
+        "horaFin": "2019-05-15T01:00:00.000Z",
+        "duracionTurno": 0,
+        "cantidadSimultaneos": null,
+        "cantidadBloque": null,
+        "accesoDirectoDelDia": 0,
+        "accesoDirectoDelDiaPorc": 0,
+        "accesoDirectoProgramado": 0,
+        "accesoDirectoProgramadoPorc": 0,
+        "reservadoGestion": 0,
+        "reservadoGestionPorc": 0,
+        "reservadoProfesional": 0,
+        "reservadoProfesionalPorc": 0,
+        "tipoPrestaciones": [{
+            "_id": "5b574e50bd7c1f8e59407f5a",
+            "fsn": "procedimiento de salud comunitaria (procedimiento)",
+            "semanticTag": "procedimiento",
+            "conceptId": "389067005",
+            "term": "actividades con la comunidad",
+            "noNominalizada": true,
+            "nombre": "actividades con la comunidad",
+            "id": "5b574e50bd7c1f8e59407f5a",
+            "activo": true
+        }],
+        "descripcion": "agenda no nominalizada",
+        "turnos": [{
+            "estado": "disponible",
+            "horaInicio": "2019-05-14T11:00:00.000Z",
+            "tipoPrestacion": {
+                "_id": "5b574e50bd7c1f8e59407f5a",
+                "fsn": "procedimiento de salud comunitaria (procedimiento)",
+                "semanticTag": "procedimiento",
+                "conceptId": "389067005",
+                "term": "actividades con la comunidad",
+                "noNominalizada": true,
+                "nombre": "actividades con la comunidad",
+                "id": "5b574e50bd7c1f8e59407f5a",
+                "activo": true
+            }
+        }],
+        "turnosMobile": false,
+        "restantesDelDia": 0,
+        "restantesProgramados": 0,
+        "restantesGestion": 0,
+        "restantesProfesional": 0,
+        "restantesMobile": 0
+    }],
+    "fecha": "2019-05-14T12:11:49.662Z",
+    "horaInicio": "2019-05-14T11:00:00.000Z",
+    "horaFin": "2019-05-15T01:00:00.000Z",
+    "tipoPrestaciones": [{
+        "_id": "5b574e50bd7c1f8e59407f5a",
+        "fsn": "procedimiento de salud comunitaria (procedimiento)",
+        "semanticTag": "procedimiento",
+        "conceptId": "389067005",
+        "term": "actividades con la comunidad",
+        "noNominalizada": true,
+        "nombre": "actividades con la comunidad",
+        "id": "5b574e50bd7c1f8e59407f5a"
+    }],
+    "espacioFisico": null,
+    "organizacion": {
+        "_id": "57e9670e52df311059bc8964",
+        "nombre": "HOSPITAL PROVINCIAL NEUQUEN - DR. EDUARDO CASTRO RENDON",
+        "id": "57e9670e52df311059bc8964"
+    }
+}

--- a/cypress/integration/apps/rup/actividades-no-nominalizadas.spec.js
+++ b/cypress/integration/apps/rup/actividades-no-nominalizadas.spec.js
@@ -1,0 +1,52 @@
+import {
+    USER_USR_LOGIN,
+    USER_PWRD_LOGIN,
+    ANDES_KEY
+} from '../../../../config.private';
+
+/// <reference types="Cypress" />
+
+context('Actividades no nominalizadas', () => {
+    let token
+    before(() => {
+        cy.login(USER_USR_LOGIN, USER_PWRD_LOGIN).then(t => {
+            token = t;
+            cy.createAgenda('agenda-no-nominalizada', token);
+
+        })
+    })
+
+    beforeEach(() => {
+        cy.viewport(1280, 720)
+        cy.visit(Cypress.env('BASE_URL') + '/rup', {
+            onBeforeLoad: (win) => {
+                win.sessionStorage.setItem('jwt', ANDES_KEY);
+            }
+        });
+    })
+
+    it('Duplicar paciente', () => {
+        cy.server();
+
+        cy.get('plex-select div input').type('actividades con la comunidad').get('div[class="selectize-dropdown-content"]').click();
+
+        cy.get('rup-puntoinicio section div div plex-box div div table tbody tr').first().click();
+
+        cy.get('rup-puntoinicio section div div plex-box div div table  tbody tr td plex-button').contains('INICIAR PRESTACIÓN').click();
+
+        cy.get('div div div button').should('have.class', 'btn-success').contains('CONFIRMAR').click();
+
+        cy.get('paciente-buscar plex-text div div input').first().type('31684354'); 
+
+        cy.get('paciente-listado table tbody tr').first().click();
+
+        cy.get('paciente-buscar plex-text div div input').first().clear();
+
+        cy.get('paciente-buscar plex-text div div input').first().type('31684354');
+
+        cy.get('paciente-listado table tbody tr').first().click();
+
+        cy.get('div').should('have.class', 'swal2-buttonswrapper').get('button').contains('Aceptar').click();
+
+    })
+})

--- a/cypress/integration/apps/rup/actividades-no-nominalizadas.spec.js
+++ b/cypress/integration/apps/rup/actividades-no-nominalizadas.spec.js
@@ -11,7 +11,7 @@ context('Actividades no nominalizadas', () => {
     before(() => {
         cy.login(USER_USR_LOGIN, USER_PWRD_LOGIN).then(t => {
             token = t;
-            cy.createAgenda('agenda-no-nominalizada', token);
+            cy.createAgenda('agenda-no-nominalizada', ANDES_KEY);
 
         })
     })
@@ -20,7 +20,7 @@ context('Actividades no nominalizadas', () => {
         cy.viewport(1280, 720)
         cy.visit(Cypress.env('BASE_URL') + '/rup', {
             onBeforeLoad: (win) => {
-                win.sessionStorage.setItem('jwt', ANDES_KEY);
+                win.sessionStorage.setItem('jwt', token);
             }
         });
     })

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -63,6 +63,26 @@ Cypress.Commands.add('createPaciente', (name, token) => {
     });
 });
 
+Cypress.Commands.add('createAgenda', (name, token) => {
+    return cy.fixture(name).then((agenda) => {
+        agenda.horaInicio = Cypress.moment().utcOffset(0);
+        agenda.horaInicio.set({ hour: 7, minute: 0, second: 0, millisecond: 0});
+
+        agenda.horaFin = Cypress.moment().utcOffset(0);
+        agenda.horaFin.set({ hour: 20   , minute: 0, second: 0, millisecond: 0});
+
+        cy.request({ 
+            method: 'POST', 
+            url: Cypress.env('API_SERVER') + '/api/modules/turnos/agenda', 
+            body: agenda,
+            headers: {
+                Authorization: `JWT ${token}`
+            }
+        });
+    });
+});
+
+
 Cypress.Commands.add('swal', (acction) => {
     return cy.get('div').then(($body) => {
         if ($body.hasClass('swal2-container')) {

--- a/examples/cypress_api.spec.js
+++ b/examples/cypress_api.spec.js
@@ -117,17 +117,17 @@ context('Cypress.config()', () => {
     expect(myConfig).to.have.property('responseTimeout', 30000)
     expect(myConfig).to.have.property('viewportHeight', 660)
     expect(myConfig).to.have.property('viewportWidth', 1000)
-    expect(myConfig).to.have.property('pageLoadTimeout', 60000)
+    expect(myConfig).to.have.property('pageLoadTimeout', 100000)
     expect(myConfig).to.have.property('waitForAnimations', true)
 
-    expect(Cypress.config('pageLoadTimeout')).to.eq(60000)
+    expect(Cypress.config('pageLoadTimeout')).to.eq(100000)
 
     // this will change the config for the rest of your tests!
     Cypress.config('pageLoadTimeout', 20000)
 
     expect(Cypress.config('pageLoadTimeout')).to.eq(20000)
 
-    Cypress.config('pageLoadTimeout', 60000)
+    Cypress.config('pageLoadTimeout', 100000)
   })
 })
 


### PR DESCRIPTION
### Requerimiento
Test de actividades no nominalizadas
andes/app#826

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Creación de json fixture para agenda-no-nominalizada
2. Creación de comando - en command.js - para el POST a la API de una nueva agenda no nominalizada.
3. Creación de archivo spec para agenda no nominalizada y con it para testear que no se pueda ingresar un paciente mas de una vez a la actividad. 

### UserStory llegó a completarse
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [ ] No
- [x] No corresponde

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [x] Si  https://github.com/andes/app/pull/1272
- [ ] No

### Requiere actualizaciones en la API
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [ ] Si
- [x] No

### Requiere actualizaciones en andes-test-integracion
<!-- Marca con una X la casilla correcta y agregar link a PR-->
- [x] Si
- [ ] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
