### PR TITLE
Perfiles de usuarios - alta y modificación con perfiles

### DIFF
--- a/cypress/integration/apps/gestor-usuarios/perfiles.spec.js
+++ b/cypress/integration/apps/gestor-usuarios/perfiles.spec.js
@@ -2,7 +2,6 @@ context('perfiles-usuario', () => {
     let token
     before(() => {
         cy.seed();
-        cy.viewport(1280, 720);
         cy.login('30643636', 'asd', '57e9670e52df311059bc8964').then(t => {
             token = t;
         });
@@ -21,25 +20,22 @@ context('perfiles-usuario', () => {
         cy.plexText('name="nombre"', 'test perfil');
         cy.get('div[id="accordion"]').eq(0).find('plex-bool').eq(0).click();
         cy.plexButton('Guardar').click();
-        cy.wait(2000);
         cy.contains('El perfil se ha guardado satisfactoriamente!');
 
     });
 
-    it.skip('Agregar permisos de un perfil existente', () => {
+    it('Agregar permisos de un perfil existente', () => {
         cy.get('table tbody tr').first().click();
         cy.get('div[id="accordion"]').eq(1).find('plex-bool').eq(0).click();
         cy.plexButton('Guardar').click();
-        cy.wait(2000);
         cy.contains('El perfil se ha guardado satisfactoriamente!');
-     });
+    });
 
-     it('Inactivar un perfil activo y verificar que se vea desactivado', () => {
+    it('Inactivar un perfil activo y verificar que se vea desactivado', () => {
         cy.get('table tbody tr').find('span').should('have.class', 'badge badge-success badge-md').first().click();
         cy.get('plex-bool[name="activo"]').click();
         cy.plexButton('Guardar').click();
-        cy.wait(2000);
         cy.contains('El perfil se ha guardado satisfactoriamente!');
-     });
+    });
 
 });

--- a/cypress/integration/apps/gestor-usuarios/perfiles.spec.js
+++ b/cypress/integration/apps/gestor-usuarios/perfiles.spec.js
@@ -1,0 +1,45 @@
+context('perfiles-usuario', () => {
+    let token
+    before(() => {
+        cy.seed();
+        cy.viewport(1280, 720);
+        cy.login('30643636', 'asd', '57e9670e52df311059bc8964').then(t => {
+            token = t;
+        });
+    });
+
+    beforeEach(() => {
+        cy.goto('/gestor-usuarios/usuarios', token);
+        cy.server();
+        cy.route('GET', '**/api/modules/gestor-usuarios/perfiles').as('perfil');
+        cy.plexButton("VER PERFILES").click();
+        cy.wait('@perfil');
+    });
+
+    it('Crear nuevo perfil', () => {
+        cy.plexButton('NUEVO').click();
+        cy.plexText('name="nombre"', 'test perfil');
+        cy.get('div[id="accordion"]').eq(0).find('plex-bool').eq(0).click();
+        cy.plexButton('Guardar').click();
+        cy.wait(2000);
+        cy.contains('El perfil se ha guardado satisfactoriamente!');
+
+    });
+
+    it.skip('Agregar permisos de un perfil existente', () => {
+        cy.get('table tbody tr').first().click();
+        cy.get('div[id="accordion"]').eq(1).find('plex-bool').eq(0).click();
+        cy.plexButton('Guardar').click();
+        cy.wait(2000);
+        cy.contains('El perfil se ha guardado satisfactoriamente!');
+     });
+
+     it('Inactivar un perfil activo y verificar que se vea desactivado', () => {
+        cy.get('table tbody tr').find('span').should('have.class', 'badge badge-success badge-md').first().click();
+        cy.get('plex-bool[name="activo"]').click();
+        cy.plexButton('Guardar').click();
+        cy.wait(2000);
+        cy.contains('El perfil se ha guardado satisfactoriamente!');
+     });
+
+});


### PR DESCRIPTION

### Requerimiento
Casos de Test: se crea un nuevo perfil y se edita el estado de los perfiles de usuarios.

### Funcionalidad desarrollada 
1. Agregar permisos de un perfil existente.
2. Inactivar un perfil activo y verificar que se vea desactivado.


### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [] Si
- [X] No

