### PR TITLE
CITAS: sumados tests para suspensión de agendas y turnos de agendas

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "npx cypress open -c baseUrl=http://localhost:4200 --env ENVIRONMENT=develop,API_SERVER=http://localhost:3002",
-    "prod": "npx cypress open -c numTestsKeptInMemory=1,baseUrl=http://localhost --env ENVIRONMENT=develop,API_SERVER=http://localhost",
+    "prod": "npx cypress open -c baseUrl=http://localhost --env ENVIRONMENT=develop,API_SERVER=http://localhost",
     "prod:run": "npx cypress run -c numTestsKeptInMemory=1,baseUrl=http://localhost --env API_SERVER=http://localhost",
     "prod:up": "node scripts/prepare.js production up",
     "prod:reset": "node scripts/prepare.js production reset",


### PR DESCRIPTION
### Requerimiento
 Agrega tests para suspensión de turnos y agendas

### Funcionalidad desarrollada 
1. Se sumó test para suspender agenda disponible sin turnos asignados y verificar estado
2. Se sumó test para suspender agenda publicada con turnos asignados y verificar estado
3. Se sumó test para suspender agenda publicada con un turno asignado y reasignar el turno que tiene a otra agenda
4. Se sumó un test para suspender turno de agenda planificada

### Requiere actualizaciones en la base de datos
- [ ] Si
- [X] No

