### PR TITLE
Dar Turno: test para rechazo de turno

### DIFF
--- a/cypress/integration/apps/citas/turnos/dar_turno.spec.js
+++ b/cypress/integration/apps/citas/turnos/dar_turno.spec.js
@@ -132,7 +132,7 @@ context('CITAS - punto de inicio', () => {
         });
 
         // Test para verificar que al no asignar el turno, guarde la organizacion
-        it.only('rechazar turno', () => {
+        it('rechazar turno', () => {
             cy.route('POST', '**/api/modules/turnos/listaEspera**').as('listaEspera');
             const paciente = pacientes[i];
             darTurno(paciente);

--- a/cypress/integration/apps/citas/turnos/dar_turno.spec.js
+++ b/cypress/integration/apps/citas/turnos/dar_turno.spec.js
@@ -131,6 +131,23 @@ context('CITAS - punto de inicio', () => {
             });
         });
 
+        // Test para verificar que al no asignar el turno, guarde la organizacion
+        it.only('rechazar turno', () => {
+            cy.route('POST', '**/api/modules/turnos/listaEspera**').as('listaEspera');
+            const paciente = pacientes[i];
+            darTurno(paciente);
+
+            cy.wait('@prestaciones');
+            cy.selectOption('name="tipoPrestacion"', '"598ca8375adc68e2a0c121d5"');
+            cy.wait('@cargaAgendas');
+            cy.get('app-calendario .dia').contains(Cypress.moment().date()).click();
+            cy.wait('@seleccionAgenda')
+            cy.plexButton('No se asigna turno').click();
+            cy.wait('@listaEspera').then((xhr) => {
+                expect(xhr.response.body).to.have.property('organizacion');
+            });
+        });
+
     })
 
 });


### PR DESCRIPTION
### Requerimiento
### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1.  Se crea test para confirmar que al momento de hacer click en al boton 'NO SE ASIGNA TURNO' se guarde la organizacion 


### Requiere actualizaciones en la base de datos
- [] Si
- [X] No

