### PR TITLE
fix(TOP): arreglo test de dar turno autocitado

### DIFF
--- a/cypress/plugins/seed-agenda.js
+++ b/cypress/plugins/seed-agenda.js
@@ -83,6 +83,10 @@ module.exports.seedAgenda = async (mongoUri, params) => {
                     labelTipoTurno = 'accesoDirectoProgramado';
                     labelTipoTurnoRestante = 'restantesProgramados';
                     break;
+                case 'profesional':
+                    labelTipoTurno = 'reservadoProfesional';
+                    labelTipoTurnoRestante = 'restantesProfesional';
+                    break;
             }
         }
 


### PR DESCRIPTION
<!--

PASOS PARA REGISTRAR UN PULL REQUEST
_____________________________________________

1) Escribir el nombre siguiendo estas reglas:
   - Indicar como prefijo el nombre del módulo
   - Si la funcionalidad corresponde a una User Story, el nombre debe coincidir son su título
   - No utilizar la palabra fix ni sus derivados

   Ejemplo: CITAS - Reglas de referencia y contrarreferencia para la carga de solicitudes

2) Seleccionar el proyecto al que pertenece (CITAS, RUP, MPI, ...)
3) Asignar revisores que sean miembros del equipo responsable de revisar el pull request
4) Completar las siguientes secciones:

-->
### Requerimiento
 <!-- URL de la User Story, referencia al issue (#1111) (o link si el issue no corresponde a este repositorio) o breve descripción del requerimiento. -->
Al correr los Pull Requests https://github.com/andes/app/pull/1531 y https://github.com/andes/api/pull/886 en jenkins no pasaba test de "dar turno autocitado"

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Se cambio la forma en que se crea agenda con turnos reservados para profesional
2. Se agrego en seed para que se puedan crear dichas agendas para profesional
3. Se agregaron diferentes controles de espera para que no falle el test


### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
