### PR TITLE
RUP: Test nota privada

### DIFF
--- a/cypress/fixtures/nota-privada.json
+++ b/cypress/fixtures/nota-privada.json
@@ -1,0 +1,7 @@
+{
+    "conceptId": "4291000013101",
+    "term": "nota privada (elemento de registro)",
+    "fsn": "nota privada (elemento de registro)",
+    "semanticTag": "elemento de registro",
+    "refsetIds": []
+}


### PR DESCRIPTION
### Requerimiento
Controlar que cuando se carga una nota privada en una prestacion, en la huds, el profesional que la registró la pueda ver y otros usuarios no.

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Se agrega test de nota privada
2. Se agrega fixture nota-privada


### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [] Si
- [x] No

### Observacion
La funcionalidad para que el profesional pueda ver la nota privada que registro todavia no esta en master, al momento de mergear ese fix se debe completar el test. 
