### PR TITLE
fix(fuera-agenda-rup): se quita click en botón seleccionar paciente

### DIFF
--- a/cypress/integration/apps/rup/colonoscopia.spec.js
+++ b/cypress/integration/apps/rup/colonoscopia.spec.js
@@ -31,7 +31,7 @@ context('prestaciones', () => {
             cy.plexSelectAsync('name="nombrePrestacion"', 'colonoscopia', '@prestaciones', 0);
 
 
-            cy.plexButton('SELECCIONAR PACIENTE').click();
+
             cy.plexText('name="buscador"', paciente.nombre);
 
             cy.get('table tbody tr').first().click();

--- a/cypress/integration/apps/rup/ejecucion.spec.js
+++ b/cypress/integration/apps/rup/ejecucion.spec.js
@@ -36,7 +36,7 @@ context('RUP - Punto de inicio', () => {
 
 
         cy.plexSelectAsync('name="nombrePrestacion"', 'consulta de medicina general', '@prestaciones', 0);
-        cy.plexButton('SELECCIONAR PACIENTE').click();
+
 
         // cy.get('plex-text input').first().type('3399661');
         cy.plexText('name="buscador"', '3399661');

--- a/cypress/integration/apps/rup/nino-sano.spec.js
+++ b/cypress/integration/apps/rup/nino-sano.spec.js
@@ -34,7 +34,7 @@ context('RUP - Punto de inicio', () => {
 
 
         cy.plexSelectAsync('name="nombrePrestacion"', 'consulta de niño sano', '@prestaciones', 0);
-        cy.plexButton('SELECCIONAR PACIENTE').click();
+
 
         cy.plexText('name="buscador"', '3399661');
 
@@ -56,18 +56,18 @@ context('RUP - Punto de inicio', () => {
             cy.wait('@search').then((xhr) => {
                 cy.get('.mdi-plus').first().click();
             });
-    
+
             cy.plexFloat('label="Peso"', 63);
             cy.plexFloat('label="Percentilo de Peso"', 70);
             cy.plexFloat('name="talla"', 120);
             cy.plexFloat('label="Percentilo de Talla"', 80);
             cy.plexFloat('label="Perímetro Cefálico"', 55);
             cy.plexFloat('label="Percentilo de Perímetro Cefálico"', 40);
-    
+
             cy.get('plex-bool').first().click();
-    
+
             cy.plexButton('Guardar consulta de niño sano').click();
-    
+
             cy.wait('@patch').then((xhr) => {
                 expect(xhr.status).to.be.eq(200);
                 expect(xhr.response.body.solicitud.turno).to.be.undefined;
@@ -76,13 +76,13 @@ context('RUP - Punto de inicio', () => {
                 expect(xhr.response.body.estados[0].tipo).to.be.eq('ejecucion');
                 expect(xhr.response.body.estados[1]).to.be.eq(undefined);
             });
-            
+
             cy.toast('success');
             cy.plexButton('Validar consulta de niño sano').click();
-    
+
             // Popup alert
             cy.get('button').contains('CONFIRMAR').click();
-    
+
             cy.wait('@patch').then((xhr) => {
                 expect(xhr.status).to.be.eq(200);
                 expect(xhr.response.body.solicitud.turno).to.be.undefined;
@@ -93,7 +93,7 @@ context('RUP - Punto de inicio', () => {
             });
             cy.wait('@codificacion').then((xhr) => {
                 expect(xhr.status).to.be.eq(200);
-    
+
             });
         });
 

--- a/cypress/integration/apps/rup/odontograma/odontograma.spec.js
+++ b/cypress/integration/apps/rup/odontograma/odontograma.spec.js
@@ -65,7 +65,7 @@ describe('RUP - Odontograma', () => {
 
 
         cy.plexSelectType('label="Seleccione el tipo de prestación"', 'Consulta de odontología').click({ force: true });
-        cy.plexButton('SELECCIONAR PACIENTE').click();
+
         cy.plexText('name="buscador"', 123456789);
         cy.wait('@searchPaciente');
         cy.get('paciente-listado').find('td').contains('123456789').click();
@@ -87,7 +87,7 @@ describe('RUP - Odontograma', () => {
 
     it('Seleccion multiple de caras de diente', () => {
         cy.plexSelectType('label="Seleccione el tipo de prestación"', 'Consulta de odontología').click({ force: true });
-        cy.plexButton('SELECCIONAR PACIENTE').click();
+
         cy.plexText('name="buscador"', 123456789);
         cy.wait('@searchPaciente');
         cy.get('paciente-listado').find('td').contains('123456789').click();
@@ -115,7 +115,7 @@ describe('RUP - Odontograma', () => {
 
     it('Guardar odontograma', () => {
         cy.plexSelectType('label="Seleccione el tipo de prestación"', 'Consulta de odontología').click({ force: true });
-        cy.plexButton('SELECCIONAR PACIENTE').click();
+
         cy.plexText('name="buscador"', 123456789);
         cy.wait('@searchPaciente');
         cy.get('paciente-listado').find('td').contains('123456789').click();
@@ -143,7 +143,7 @@ describe('RUP - Odontograma', () => {
 
     it('Registrar Tratamiento de conducto', () => {
         cy.plexSelectType('label="Seleccione el tipo de prestación"', 'Consulta de odontología').click({ force: true });
-        cy.plexButton('SELECCIONAR PACIENTE').click();
+
         cy.plexText('name="buscador"', 123456789);
         cy.wait('@searchPaciente');
         cy.get('paciente-listado').find('td').contains('123456789').click();
@@ -186,7 +186,7 @@ describe('RUP - Odontograma', () => {
 
     it('Desvincular Caras', () => {
         cy.plexSelectType('label="Seleccione el tipo de prestación"', 'Consulta de odontología').click({ force: true });
-        cy.plexButton('SELECCIONAR PACIENTE').click();
+
         cy.plexText('name="buscador"', 123456789);
         cy.wait('@searchPaciente');
         cy.get('paciente-listado').find('td').contains('123456789').click();

--- a/cypress/integration/apps/solicitud/solicitudes.spec.js
+++ b/cypress/integration/apps/solicitud/solicitudes.spec.js
@@ -299,7 +299,7 @@ context('TOP', () => {
 
         cy.get('plex-button[label="PACIENTE FUERA DE AGENDA"]').click();
         cy.selectOption('name="nombrePrestacion"', '"59ee2d9bf00c415246fd3d6a"');
-        cy.get('plex-button[label="SELECCIONAR PACIENTE"]').click();
+
         cy.get('plex-text input[type=text]').first().type('38906735').should('have.value', '38906735');
         cy.get('tr').eq(1).click()
         cy.get('plex-button[label="INICIAR PRESTACIÓN"]').click();


### PR DESCRIPTION
### Funcionalidad desarrollada 
1. Se quitó un click en un botón que ya no existe (seleccionar paciente) al crear una Prestación Fuera de Agenda, ya que ahora simplemente aparece el campo de búsqueda directamente.


### Requiere actualizaciones en la base de datos
- [ ] Si
- [X] No

~~cy.plexButton('SELECCIONAR PACIENTE').click();~~
