### PR TITLE
MONITOREO: sumados tests de buscador de snomed y nuevos comandos 

### DIFF
--- a/cypress/integration/monitoreo/buscador-snomed.spec.js
+++ b/cypress/integration/monitoreo/buscador-snomed.spec.js
@@ -1,0 +1,46 @@
+context('Buscador de conceptos SNOMED', () => {
+    let token;
+    const conceptAutocitacion = [
+        {
+            "conceptId": "811000013106",
+            "fsn": "Autocitación (procedimiento)",
+            "semanticTag": "procedimiento",
+            "term": "Autocitación",
+            "refsetIds": []
+        }
+    ];
+
+    before(() => {
+        cy.login('38906735', 'asd').then(t => {
+            token = t;
+        });
+    });
+
+    beforeEach(() => {
+        cy.server();
+        cy.goto('/monitoreo/home', token);
+        cy.route('GET', '**/api/core/term/snomed?search=concepto cualquiera', []).as('busquedaInexistente');
+        cy.route('GET', '**/api/core/term/snomed?search=autocitacion', conceptAutocitacion).as('busquedaAutocitacion');
+    });
+
+    it('buscar concepto por term y verificar que no existe', () => {
+        cy.plexMenu('magnify');
+        cy.plexText('name="searchTerm"', 'concepto cualquiera');
+        cy.wait('@busquedaInexistente').then((xhr) => {
+            expect(xhr.status).to.be.eq(200);
+            cy.get('plex-item').should('have.length', 0);
+        });
+    });
+
+    it('buscar concepto por term y verificar existe', () => {
+        cy.plexMenu('magnify');
+        cy.plexText('name="searchTerm"', 'autocitacion');
+        cy.wait('@busquedaAutocitacion').then((xhr) => {
+            expect(xhr.status).to.be.eq(200);
+            cy.get('plex-item').should('have.length', 1);
+            cy.plexBadge('procedimiento', 'buscador');
+            cy.plexLabel('Autocitación');
+            cy.plexLabel('811000013106');
+        });
+    });
+});

--- a/cypress/support/plex.js
+++ b/cypress/support/plex.js
@@ -151,6 +151,31 @@ Cypress.Commands.add('plexText', { prevSubject: 'optional' }, (subject, label, t
     return element;
 });
 
+Cypress.Commands.add('plexLabel', { prevSubject: 'optional' }, (subject, label) => {
+    let element;
+    if (subject) {
+        element = cy.wrap(subject).find('plex-label', { timeout: 30000 }).contains(label);
+    } else {
+        element = cy.get('plex-label', { timeout: 30000 }).contains(label);
+    }
+    return element;
+});
+
+Cypress.Commands.add('plexBadge', { prevSubject: 'optional' }, (subject, label, type = null) => {
+    let element;
+    if (subject) {
+        element = cy.wrap(subject).find('plex-badge', { timeout: 30000 })
+    } else {
+        element = cy.get('plex-badge', { timeout: 30000 });
+    }
+    if (type) {
+        element = element.find(`.badge-${type}`, { timeout: 30000 }).contains(label);
+    } else {
+        element = element.contains(label);
+    }
+    return element;
+});
+
 Cypress.Commands.add('plexTextArea', { prevSubject: 'optional' }, (subject, label, text = null) => {
     let element;
     if (subject) {


### PR DESCRIPTION
### Requerimiento
Desarrollo de tests para el buscador de SNOMED en Monitoreo

### Funcionalidad desarrollada 
1. Test para la búsqueda de un concepto por term y verificar que no existe
2. Test para la búsqueda de un concepto por term y verificar que existe
3. Nuevos comandos plexLabel y plexBadge

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [X] No
