### PR TITLE
chore(docker): quita la base de mpi

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -39,7 +39,6 @@ services:
     environment:
       APP_KEY: "5gCYFZPp3dfA2m5UNElVkgRLFcFnlele"
       MONGO_MAIN: "mongodb://andes_db:27017/andes"
-      MONGO_MPI: "mongodb://andes_db:27017/mpi"
       MONGO_SNOMED: "mongodb://andes_db:27017/es-edition"
       MONGO_PUCO: "mongodb://andes_db:27017/padrones"
       MONGO_LOGS: "mongodb://andes_db:27017/logs"


### PR DESCRIPTION
### Requerimiento
Remueve la conexión a la base de datos MPI

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Modificación en docker-compose
2. 
3. 


### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [X] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
