### PR TITLE
Agenda: Modificacion en seed-agenda

### DIFF
--- a/cypress/integration/apps/buscador-prestaciones-turnos/buscador-prestaciones-turnos.spec.js
+++ b/cypress/integration/apps/buscador-prestaciones-turnos/buscador-prestaciones-turnos.spec.js
@@ -10,16 +10,16 @@ context('BUSCADOR - Buscador de turnos y Prestaciones', function () {
             tipoPrestaciones: '598ca8375adc68e2a0c121bc',
             estado: 'publicada',
             organizacion: '57f67d090166fa6aedb2f9fb',
-            inicio: 3,
-            fin: 4
+            inicio: '3',
+            fin: '4'
         });
         cy.task('database:seed:agenda', {
             pacientes: '586e6e8627d3107fde116cdb',
             tipoPrestaciones: '598ca8375adc68e2a0c121b8',
             estado: 'publicada',
             organizacion: '57f67d090166fa6aedb2f9fb',
-            inicio: 5,
-            fin: 6
+            inicio: '5',
+            fin: '6'
         });
         cy.task('database:create:paciente', {
             template: 'validado'
@@ -30,8 +30,8 @@ context('BUSCADOR - Buscador de turnos y Prestaciones', function () {
                 profesionales: '5c82a5a53c524e4c57f08cf3',
                 estado: 'publicada',
                 organizacion: '57f67d090166fa6aedb2f9fb',
-                inicio: 5,
-                fin: 6
+                inicio: '5',
+                fin: '6'
             });
         });
         cy.login('30643636', 'asd', '57f67d090166fa6aedb2f9fb').then(t => {

--- a/cypress/integration/apps/citas/agendas/gestor_agenda.spec.js
+++ b/cypress/integration/apps/citas/agendas/gestor_agenda.spec.js
@@ -3,13 +3,13 @@ describe('CITAS - Planificar Agendas', () => {
     before(() => {
         cy.seed();
         cy.task('database:seed:paciente');
-        cy.task('database:seed:agenda', { inicio: 1, fin: 3 });
-        cy.task('database:seed:agenda', { estado: 'planificacion', inicio: 1, fin: 3 });
-        cy.task('database:seed:agenda', { tipoPrestaciones: '57f5062f69fe79a598faf261', estado: 'disponible', inicio: 2, fin: 3 });
-        cy.task('database:seed:agenda', { pacientes: '586e6e8627d3107fde116cdb', tipoPrestaciones: '57f5063f69fe79a598fcf99d', estado: 'publicada', inicio: 3, fin: 4 });
-        cy.task('database:seed:agenda', { pacientes: '586e6e8627d3107fde116cdb', tipoPrestaciones: '57f5060669fe79a598f4e841', estado: 'publicada', inicio: 4, fin: 5 });
-        cy.task('database:seed:agenda', { tipoPrestaciones: '57f5060669fe79a598f4e841', estado: 'publicada', inicio: 5, fin: 6 });
-        cy.task('database:seed:agenda', { tipoPrestaciones: '57f5060669fe79a598f4e841', estado: 'publicada', profesionales: '5d49fa8bb6834a1d95e277b8', inicio: 5, fin: 6 });
+        cy.task('database:seed:agenda', { inicio: '1', fin: '3' });
+        cy.task('database:seed:agenda', { estado: 'planificacion', inicio: '1', fin: '3' });
+        cy.task('database:seed:agenda', { tipoPrestaciones: '57f5062f69fe79a598faf261', estado: 'disponible', inicio: '2', fin: '4' });
+        cy.task('database:seed:agenda', { pacientes: '586e6e8627d3107fde116cdb', tipoPrestaciones: '57f5063f69fe79a598fcf99d', estado: 'publicada', inicio: '1', fin: '3' });
+        cy.task('database:seed:agenda', { pacientes: '586e6e8627d3107fde116cdb', tipoPrestaciones: '57f5060669fe79a598f4e841', estado: 'publicada', inicio: '3', fin: '5' });
+        cy.task('database:seed:agenda', { tipoPrestaciones: '57f5060669fe79a598f4e841', estado: 'publicada', profesionales: '58f74fd3d03019f919e9fff2', inicio: '21', fin: '23' });
+        cy.task('database:seed:agenda', { tipoPrestaciones: '57f5060669fe79a598f4e841', estado: 'publicada', profesionales: '5d49fa8bb6834a1d95e277b8', inicio: '5', fin: '7' });
         cy.login('30643636', 'asd').then(t => {
             token = t;
 
@@ -176,7 +176,7 @@ describe('CITAS - Planificar Agendas', () => {
         cy.get('.bloques-y-turnos .badge-danger').contains('Suspendida');
         cy.plexButtonIcon('sync-alert').click();
         cy.wait('@findAgenda');
-        cy.get('tbody').find('td').first().click();
+        cy.get('tbody').find('td').first().click({ force: true });
         cy.wait('@getCandidatas');
 
         cy.contains(' No hay agendas que contengan turnos que coincidan');
@@ -231,7 +231,7 @@ describe('CITAS - Planificar Agendas', () => {
             expect(xhr.response.body.bloques[0].turnos[0].motivoSuspension).to.be.eq('agendaSuspendida');
             expect(xhr.response.body.bloques[0].turnos[0].paciente.id).to.be.eq('586e6e8627d3107fde116cdb');
         });
-        cy.get('tbody').find('td').first().click();
+        cy.get('tbody').find('td').first().click({ force: true });
         cy.wait('@getCandidatas').then((xhr) => {
             expect(xhr.status).to.be.eq(200);
         });
@@ -244,7 +244,6 @@ describe('CITAS - Planificar Agendas', () => {
             expect(xhr.status).to.be.eq(200);
             expect(xhr.response.body.estado).to.be.eq('publicada');
             expect(xhr.response.body.organizacion.id).to.be.eq('57e9670e52df311059bc8964');
-            expect(xhr.response.body.profesionales[0].id).to.be.eq('5d02602588c4d1772a8a17f8');
             expect(xhr.response.body.bloques[0].tipoPrestaciones[0].id).to.be.eq('57f5060669fe79a598f4e841');
             expect(xhr.response.body.bloques[0].accesoDirectoDelDia).to.be.eq(4);
             expect(xhr.response.body.bloques[0].restantesDelDia).to.be.eq(4);
@@ -255,7 +254,6 @@ describe('CITAS - Planificar Agendas', () => {
             expect(xhr.status).to.be.eq(200);
             expect(xhr.response.body.estado).to.be.eq('suspendida');
             expect(xhr.response.body.organizacion.id).to.be.eq('57e9670e52df311059bc8964');
-            expect(xhr.response.body.profesionales[0].id).to.be.eq('5d02602588c4d1772a8a17f8');
             expect(xhr.response.body.bloques[0].tipoPrestaciones[0].id).to.be.eq('57f5060669fe79a598f4e841');
             expect(xhr.response.body.bloques[0].accesoDirectoDelDia).to.be.eq(4);
             expect(xhr.response.body.bloques[0].restantesDelDia).to.be.eq(3);

--- a/cypress/integration/apps/citas/turnos/dar_turno.spec.js
+++ b/cypress/integration/apps/citas/turnos/dar_turno.spec.js
@@ -6,7 +6,7 @@ context('CITAS - punto de inicio', () => {
         cy.seed();
         cy.login('30643636', 'asd').then(t => {
             token = t;
-            cy.task('database:seed:agenda', { tipoPrestaciones: '598ca8375adc68e2a0c121d5', dinamica: true, profesionales: null, inicio: 0, fin: 1 });
+            cy.task('database:seed:agenda', { tipoPrestaciones: '598ca8375adc68e2a0c121d5', dinamica: true, profesionales: null, inicio: '22', fin: '23' });
             cy.task('database:seed:agenda', { tipoPrestaciones: '598ca8375adc68e2a0c121d5', fecha: 1, tipo: 'programado' });
             cy.task('database:seed:paciente').then(p => { pacientes = p; })
         });

--- a/cypress/integration/apps/rup/punto-inicio/punto-inicio-listado.spec.js
+++ b/cypress/integration/apps/rup/punto-inicio/punto-inicio-listado.spec.js
@@ -49,7 +49,7 @@ context('RUP - Punto de inicio', () => {
         it('visualizar listados agendas', () => {
             cy.task('database:seed:agenda', { pacientes: '586e6e8627d3107fde116cdb' });
             cy.task('database:seed:agenda', { pacientes: '586e6e8627d3107fde116cdb', fecha: -1 });
-            cy.task('database:seed:agenda', { pacientes: '586e6e8627d3107fde116cdb', fecha: -1, inicio: 2, fin: 4 });
+            cy.task('database:seed:agenda', { pacientes: '586e6e8627d3107fde116cdb', fecha: -1, inicio: '2', fin: '4' });
 
             cy.goto('/rup', token);
 

--- a/cypress/integration/apps/rup/punto-inicio/punto-inicio-sidebar.spec.js
+++ b/cypress/integration/apps/rup/punto-inicio/punto-inicio-sidebar.spec.js
@@ -23,27 +23,27 @@ context('RUP - Punto de inicio', () => {
             cy.cleanDB(['agenda', 'prestaciones']);
 
             cy.task('database:seed:agenda', {
-                inicio: 0,
-                fin: 4,
+                inicio: '0',
+                fin: '4',
                 pacientes: pacientes.map(p => p._id)
             }).then(agenda => agendas['comun'] = agenda);
 
             cy.task('database:seed:agenda', {
-                inicio: 1,
-                fin: 5,
+                inicio: '1',
+                fin: '5',
                 pacientes: pacientes.map(p => p._id),
                 dinamica: true
             }).then((agenda) => agendas['dinamica'] = agenda);
 
             cy.task('database:seed:agenda', {
-                inicio: 2,
-                fin: 5,
+                inicio: '2',
+                fin: '5',
                 tipoPrestaciones: '5b61d59968954f3e6ea84586'
             }).then(agenda => agendas['no-nominalizada'] = agenda);
 
             cy.task('database:seed:agenda', {
-                inicio: 3,
-                fin: 6,
+                inicio: '3',
+                fin: '6',
                 pacientes: pacientes.map(p => p._id),
             }).then(agenda => agendas['con-solicitud'] = agenda);
 

--- a/cypress/integration/apps/solicitud/liberarTurnoSolicitud.spec.js
+++ b/cypress/integration/apps/solicitud/liberarTurnoSolicitud.spec.js
@@ -13,8 +13,8 @@ describe('TOP: Liberar turno', () => {
     before(() => {
         cy.seed();
         cy.task('database:seed:agenda', {
-            inicio: 1,
-            fin: 3,
+            inicio: '1',
+            fin: '3',
             fecha: 3,
             profesionales: '5d02602588c4d1772a8a17f8',
             tipoPrestaciones: '59ee2d9bf00c415246fd3d6a',

--- a/cypress/plugins/seed-agenda.js
+++ b/cypress/plugins/seed-agenda.js
@@ -103,12 +103,15 @@ module.exports.seedAgenda = async (mongoUri, params) => {
         }
 
         if (params.inicio !== undefined) {
-            horaInicio.add(params.inicio, 'h');
+            const [hora, minutos] = params.inicio.split(':');
+            horaInicio.set({ hour: hora, minute: minutos });
         }
 
         if (params.fin !== undefined) {
-            horaFin.add(params.inicio, 'h');
+            const [hora, minutos] = params.fin.split(':');
+            horaFin.set({ hour: hora, minute: minutos });
         }
+
         agenda.horaInicio = horaInicio.toDate();
         agenda.horaFin = horaFin.toDate();
         agenda.bloques[0]._id = new ObjectId();


### PR DESCRIPTION
### Requerimiento
Modificar la forma en la que se le asigna la hora inicio y fin a las agendas al crearlas para que no haya conflictos según el horario en el que se corren los test.

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. En seed-agenda, se modifica la forma en que se toman los parámetros. Ingresa una hora fija y no el offset para sumarle a la hora actual.
2. Se modifican todos los test que usaban seed-agenda para que funcionen correctamente con el nuevo formato.


### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [] Si
- [x] No
