### PR TITLE
Fix: Arregla id de profesional de solicitud en seed de prestación

### DIFF
--- a/cypress/plugins/seed-prestaciones.js
+++ b/cypress/plugins/seed-prestaciones.js
@@ -67,7 +67,7 @@ module.exports.seedPrestacion = async (mongoUri, params) => {
             const profesional = await ProfesionalDB.findOne({ _id: new ObjectId(params.profesional) });
             prestacion.solicitud.profesional = profesional;
         } else {
-            prestacion.solicitud.profesional._id = new ObjectId(prestacion.solicitud.profesional._id);
+            prestacion.solicitud.profesional.id = new ObjectId(prestacion.solicitud.profesional._id);
         }
 
         if (params.paciente) {


### PR DESCRIPTION
<!--

PASOS PARA REGISTRAR UN PULL REQUEST
_____________________________________________

1) Escribir el nombre siguiendo estas reglas:
   - Indicar como prefijo el nombre del módulo
   - Si la funcionalidad corresponde a una User Story, el nombre debe coincidir son su título
   - No utilizar la palabra fix ni sus derivados

   Ejemplo: CITAS - Reglas de referencia y contrarreferencia para la carga de solicitudes

2) Seleccionar el proyecto al que pertenece (CITAS, RUP, MPI, ...)
3) Asignar revisores que sean miembros del equipo responsable de revisar el pull request
4) Completar las siguientes secciones:

-->
### Requerimiento
El en seed de prestación, el `id` de profesional de solicitud (`prestacion.solicitud.profesional.id`), actualmente se está guardando como `_id`. Esto repercute en que las prestaciones generadas desde el seed no pueden ser encontradas por la API al ser filtradas por idProfesional.
 <!-- URL de la User Story, referencia al issue (#1111) (o link si el issue no corresponde a este repositorio) o breve descripción del requerimiento. -->

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Arregla id de profesional de solicitud en seed de prestación


### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [] Si
- [x] No


<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
