### PR TITLE
fix(agenda): remove scrollto

### DIFF
--- a/cypress/integration/apps/citas/agendas/revision-agenda/revision_agendas_con_paciente.spec.js
+++ b/cypress/integration/apps/citas/agendas/revision-agenda/revision_agendas_con_paciente.spec.js
@@ -77,9 +77,6 @@ context('CITAS - Revisión de Agendas', () => {
         cy.goto(`/citas/revision_agenda/${idAgenda}`, token);
         cy.get('tbody:nth-child(1) tr:first-child').click();
 
-        cy.get('plex-layout-main .plex-box-content').scrollTo('bottom');
-        cy.wait(500);
-
         // Hay que corregir el plex-button, ya que debería funcionar así:
         cy.plexButtonIcon('refresh').click();
 
@@ -132,9 +129,6 @@ context('CITAS - Revisión de Agendas', () => {
         cy.route('GET', '**/api/core/mpi/pacientes**').as('listaPacientes');
 
         cy.goto(`/citas/revision_agenda/${idAgenda}`, token);
-
-        // Ver cómo detectar si hay scroll
-        // cy.get('plex-layout-sidebar .plex-box-content').scrollTo('bottom');
 
         cy.wait('@agenda').then(xhrAgenda => {
             cy.expect(xhrAgenda.status).to.be.eq(200);


### PR DESCRIPTION
# Requerimiento

El nuevo plex-content no permite scrollTo debido a una clase de CSS:

### Requiere actualizaciones en la base de datos
- [ ] Si
- [ ] No
