### PR TITLE
Obra-Social: Elimina llamado a getObraSocial

### DIFF
--- a/cypress/integration/apps/citas/turnos/punto_inicio.spec.js
+++ b/cypress/integration/apps/citas/turnos/punto_inicio.spec.js
@@ -44,8 +44,6 @@ context('punto de inicio', () => {
 
     it('Generar solicitud', () => {
         cy.route('GET', '**api/modules/rup/prestaciones/solicitudes?idPaciente=**').as('generarSolicitudPaciente');
-        cy.route('GET', '/api/modules/obraSocial/obraSocial/**', []).as('version');
-        // const search = paciente.documento;
         cy.plexText('name=buscador', paciente.documento);
         cy.wait('@busquedaPaciente').then((xhr) => {
             expect(xhr.status).to.be.eq(200);
@@ -72,7 +70,6 @@ context('punto de inicio', () => {
             "account": null
         }).as('activarApp');
 
-        cy.route('GET', '/api/modules/obraSocial/obraSocial/**', []).as('puco');
         cy.route('GET', '/api/modules/obraSocial/prepagas/**', []).as('prepagas');
         cy.plexText('name=buscador', paciente.documento);
         cy.wait('@busquedaPaciente').then((xhr) => {
@@ -102,7 +99,6 @@ context('punto de inicio', () => {
         cy.route('GET', '**/api/core/mpi/pacientes/**').as('getPaciente');
         cy.route('GET', '**/api/modules/turnos/historial?**').as('getHistorial');
         cy.route('GET', '**/api/core/log/paciente?**').as('getLog');
-        cy.route('GET', '**/api/modules/obraSocial/obraSocial/**').as('getObraSocial');
         cy.route('GET', '**/api/modules/obraSocial/prepagas**').as('getPrepagas');
         cy.route('GET', '**/api/core/tm/localidades?**').as('getLocalidades');
         cy.route('GET', '**/api/core/tm/paises?**').as('getPaises');
@@ -127,10 +123,6 @@ context('punto de inicio', () => {
         });
 
         cy.wait('@getLog').then((xhr) => {
-            expect(xhr.status).to.be.eq(200);
-        });
-
-        cy.wait('@getObraSocial').then((xhr) => {
             expect(xhr.status).to.be.eq(200);
         });
 
@@ -174,7 +166,6 @@ context('punto de inicio', () => {
         cy.route('GET', '**/api/core/mpi/pacientes/**').as('getPaciente');
         cy.route('GET', '**/api/modules/turnos/historial?**').as('getTurnos');
         cy.route('GET', '**/api/core/log/paciente?**').as('getLog');
-        cy.route('GET', '**/api/modules/obraSocial/obraSocial/**').as('getObraSocial');
         cy.route('GET', '**/api/core/tm/paises?**').as('getPaises');
         cy.route('GET', '**/api/modules/obraSocial/prepagas**').as('getPrepagas');
         cy.route('GET', '**/api/core/tm/provincias**').as('getProvincias');
@@ -196,10 +187,6 @@ context('punto de inicio', () => {
         });
 
         cy.wait('@getLog').then((xhr) => {
-            expect(xhr.status).to.be.eq(200);
-        });
-
-        cy.wait('@getObraSocial').then((xhr) => {
             expect(xhr.status).to.be.eq(200);
         });
 
@@ -260,7 +247,6 @@ context('punto de inicio', () => {
         cy.route('GET', '**/api/core/mpi/pacientes/**').as('getPaciente');
         cy.route('GET', '**/api/modules/turnos/historial?**').as('getTurnos');
         cy.route('GET', '**/api/core/log/paciente?**').as('getLog');
-        cy.route('GET', '**/api/modules/obraSocial/obraSocial/**').as('getObraSocial');
         cy.route('GET', '**/api/core/tm/paises?**').as('getPaises');
         cy.route('GET', '**/api/modules/obraSocial/prepagas**').as('getPrepagas');
         cy.route('GET', '**/api/core/tm/provincias**').as('getProvincias');
@@ -283,10 +269,6 @@ context('punto de inicio', () => {
         });
 
         cy.wait('@getLog').then((xhr) => {
-            expect(xhr.status).to.be.eq(200);
-        });
-
-        cy.wait('@getObraSocial').then((xhr) => {
             expect(xhr.status).to.be.eq(200);
         });
 

--- a/cypress/integration/apps/rup/ejecucion.spec.js
+++ b/cypress/integration/apps/rup/ejecucion.spec.js
@@ -28,7 +28,6 @@ context('RUP - Punto de inicio', () => {
         cy.route('GET', '/api/modules/rup/prestaciones/huds/**', []).as('huds');
         cy.route('GET', '**api/core/tm/tiposPrestaciones**').as('prestaciones');
         cy.route('POST', '**/api/modules/rup/prestaciones').as('create');
-        cy.route('GET', '/api/modules/obraSocial/os/**', []).as('obraSocial');
         cy.route('PATCH', 'api/modules/rup/prestaciones/**').as('patch');
         cy.route('GET', '**api/core/mpi/pacientes?**').as('pacientes');
 
@@ -248,7 +247,6 @@ context('RUP - Punto de inicio', () => {
         cy.route('GET', '/api/modules/rup/prestaciones/huds/**', []).as('huds');
         cy.route('GET', '**api/core/tm/tiposPrestaciones**').as('prestaciones');
         cy.route('POST', '**/api/modules/rup/prestaciones').as('create');
-        cy.route('GET', '/api/modules/obraSocial/os/**', []).as('obraSocial');
         cy.route('PATCH', 'api/modules/rup/prestaciones/**').as('patch');
 
         cy.plexButton('PACIENTE FUERA DE AGENDA').click();

--- a/cypress/integration/apps/rup/nino-sano.spec.js
+++ b/cypress/integration/apps/rup/nino-sano.spec.js
@@ -23,7 +23,6 @@ context('RUP - Punto de inicio', () => {
         cy.route('GET', '/api/modules/rup/prestaciones/huds/**', []).as('huds');
         cy.route('GET', '**api/core/tm/tiposPrestaciones**').as('prestaciones');
         cy.route('POST', '**/api/modules/rup/prestaciones').as('create');
-        cy.route('GET', '/api/modules/obraSocial/os/**', []).as('obraSocial');
         cy.route('PATCH', 'api/modules/rup/prestaciones/**').as('patch');
         cy.route('GET', '/api/core/term/snomed/expression**', []).as('expression');
         cy.route('POST', '/api/modules/rup/codificacion').as('codificacion');


### PR DESCRIPTION
### Requerimiento
Modificar test para funcionar correctamente con el nuevo cambio en obras sociales

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Se eliminaron las llamadas a los get de obra social


### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [] Si
- [x] No

### Observaciones
Debe correrse en las ramas https://github.com/andes/api/pull/1010 y https://github.com/andes/app/pull/1752


![Captura de pantalla -2020-06-18 11-39-20](https://user-images.githubusercontent.com/56874534/85035250-54bb7b00-b159-11ea-99f4-870b335b83cd.png)
![Captura de pantalla -2020-06-18 11-35-04](https://user-images.githubusercontent.com/56874534/85035258-55eca800-b159-11ea-8572-06f91102ffd6.png)
![Captura de pantalla -2020-06-18 11-32-02](https://user-images.githubusercontent.com/56874534/85035259-56853e80-b159-11ea-8f47-52cf92d17868.png)
![Captura de pantalla -2020-06-18 11-30-34](https://user-images.githubusercontent.com/56874534/85035260-571dd500-b159-11ea-97fd-97688bbe1d03.png)

