### PR TITLE
MPI: se cambia plexText por plexPhone

### DIFF
--- a/cypress/integration/apps/citas/turnos/punto_inicio.spec.js
+++ b/cypress/integration/apps/citas/turnos/punto_inicio.spec.js
@@ -76,7 +76,7 @@ context('punto de inicio', () => {
         cy.get('paciente-listado').find('td').contains(paciente.documento).click();
         cy.plexButtonIcon('cellphone-android').click();
         cy.plexText('placeholder="e-mail"', '{selectall}{backspace}prueba@prueba.com');
-        cy.plexText('placeholder="Celular"', '{selectall}{backspace}2995290357');
+        cy.plexPhone('name="celular"', '{selectall}{backspace}2995290357');
         cy.plexButton('Activar App Mobile').click();
         cy.swal('confirm')
     })


### PR DESCRIPTION
### Requerimiento
Modificar el campo celular en el caso de la activación de la app mobile por plex-phone dado cambio en la app.

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. En test de activacion de app mobile, se modifica el campo celular.

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [] Si
- [x] No

![Captura de pantalla -2020-06-18 15-56-11](https://user-images.githubusercontent.com/56874534/85061321-0324e780-b17d-11ea-8748-1ec69ceea808.png)

