### PR TITLE
RUP: arreglo de tests para rama RUP-165

### DIFF
--- a/cypress/integration/apps/rup/punto-inicio/punto-inicio-listado.spec.js
+++ b/cypress/integration/apps/rup/punto-inicio/punto-inicio-listado.spec.js
@@ -42,8 +42,7 @@ context('RUP - Punto de inicio', () => {
             cy.get('plex-radio[name="agendas"] input').eq(1).click({
                 force: true
             });
-            cy.get('table').first().find('tbody tr').should('have.length', 1);
-
+            cy.get('tbody tr').contains('PEREZ, MARIA').click();
         });
 
         it('visualizar listados agendas', () => {


### PR DESCRIPTION
### Requerimiento
Se corrige tests que fallaba con https://github.com/andes/app/pull/1873

### Funcionalidad desarrollada 
1. Se agrega un control por nombre de profesional en test _'no visualiza agendas de otros profesionales'_ 

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [X] No
