### PR TITLE
fix(anular-solicitud): para que tome los cambios en la anulación

### DIFF
--- a/cypress/fixtures/solicitudes/solicitud-pendiente.json
+++ b/cypress/fixtures/solicitudes/solicitud-pendiente.json
@@ -1,0 +1,79 @@
+{
+    "paciente": {
+        "id": "5d4a073f73aa36303266d09d",
+        "nombre": "TEST",
+        "apellido": "SOLICITUD",
+        "documento": "32589654",
+        "sexo": "femenino",
+        "fechaNacimiento": "1987-01-01T03:00:00.000Z"
+    },
+    "solicitud": {
+        "organizacion": {
+            "_id": "57e9670e52df311059bc8964",
+            "id": "57e9670e52df311059bc8964",
+            "nombre": "HOSPITAL PROVINCIAL NEUQUEN - DR. EDUARDO CASTRO RENDON"
+        },
+        "organizacionOrigen": {
+            "id": "57fcf038326e73143fb48dac",
+            "nombre": "HOSPITAL DR. HORACIO HELLER"
+        },
+        "profesional": null,
+        "profesionalOrigen": {
+            "_id": "58f74fd3d03019f919e9fff2",
+            "nombre": "JAZMIN",
+            "apellido": "CORTES",
+            "documento": "4402222",
+            "nombreCompleto": "CORTES, JAZMIN",
+            "id": "58f74fd3d03019f919e9fff2"
+        },
+        "fecha": "2019-08-01T10:00:00.000-03:00",
+        "turno": null,
+        "tipoPrestacion": {
+            "conceptId":"251000013108",
+            "term":"consulta de endocrinología",
+            "fsn":"consulta de endocrinología",
+            "semanticTag":"procedimiento",
+             "auditable":true,
+             "_id":"5bc8849b273ff26bc112efbc",
+             "id":"5bc8849b273ff26bc112efbc",
+            "nombre": "Consulta de endocrinología"
+        },
+        "tipoPrestacionOrigen": {
+            "refsetIds": [],
+            "conceptId": "401000013105",
+            "term": "consulta de clínica médica",
+            "fsn": "consulta de clínica médica",
+            "semanticTag": "procedimiento"
+        },
+        "registros": [
+            {
+                "nombre": "Consulta de neurología",
+                "concepto": {
+                    "auditable": true,
+                    "_id": "59ee2d9bf00c415246fd3d6d",
+                    "fsn": "Consulta de neurología (procedimiento)",
+                    "semanticTag": "procedimiento",
+                    "conceptId": "421000013100",
+                    "term": "Consulta de neurología",
+                    "nombre": "Consulta de neurología",
+                    "id": "59ee2d9bf00c415246fd3d6d"
+                },
+                "valor": {
+                    "solicitudPrestacion": {
+                        "motivo": "Motivo de la solicitud",
+                        "autocitado": false
+                    },
+                    "documentos": []
+                },
+                "tipo": "solicitud"
+            }
+        ]
+    },
+    "estados": [
+        {
+            "tipo": "pendiente"
+        }
+    ],
+    "inicio": "top",
+    "prestacionOrigen": null
+}

--- a/cypress/integration/apps/solicitud/anularSolicitud.spec.js
+++ b/cypress/integration/apps/solicitud/anularSolicitud.spec.js
@@ -12,56 +12,36 @@ context('ANULAR SOLICITUD', () => {
         cy.login('30643636', 'asd').then(t => {
             token = t;
             cy.createPaciente('solicitudes/paciente-solicitud', token);
-            cy.createPrestacion('solicitudes/solicitud-auditoria', token)
-        })
-    })
+            cy.createPrestacion('solicitudes/solicitud-pendiente', token);
+        });
+    });
 
      beforeEach(() => {
         cy.goto('/solicitudes', token);
         cy.server();
         cy.route('GET', '**/api/modules/rup/prestaciones/solicitudes**').as('solicitudes');
-        cy.route('POST', '**/api/modules/rup/prestaciones').as('guardarSolicitud');
-        cy.route('PATCH', '**/api/modules/rup/prestaciones/**').as('auditarSolicitud');
-    })
-
-    it('aceptar', () => {
-        cy.server();
-        cy.plexButtonIcon('lock-alert').first().click();
-        cy.plexButton('Aceptar').click();
-        cy.get('textarea').last().type('Una observacion aceptar', { force: true });
-        cy.plexButton('Confirmar').click();
-        cy.wait('@auditarSolicitud').then((xhr) => {
-            const i = xhr.response.body.solicitud.historial.length - 1;
-            expect(xhr.status).to.be.eq(200);
-            expect(xhr.response.body.solicitud.historial[i].descripcion).to.be.eq('Aceptada');
-            expect(xhr.response.body.solicitud.historial[i].observaciones).to.be.eq('Una observacion aceptar');  
-        });
-        cy.get('plex-badge').contains('pendiente');
-        cy.plexButtonIcon('calendar-plus');
-        anular();
-    })
-})
-
-function anular() {
-    cy.plexButtonIcon('delete').click();
-    cy.get('textarea').last().type('Una observacion anular', { force: true });
-    cy.plexButton('Confirmar').click();
-    cy.wait('@auditarSolicitud').then((xhr) => {
-        expect(xhr.status).to.be.eq(200);
-        const i = xhr.response.body.solicitud.historial.length - 1;
-        expect(xhr.response.body.solicitud.historial[i].observaciones).to.be.eq('Una observacion anular');  
-        expect(xhr.response.body.solicitud.historial[i].accion).to.be.eq('anulada');
-        expect(xhr.response.body.solicitud.historial[i].descripcion).to.be.eq('Anulada');
+        cy.route('PATCH', '**/api/modules/rup/prestaciones/**').as('anularSolicitud');
     });
-    cy.wait('@solicitudes');
-    cy.plexButtonIcon('chevron-down').click();
-    cy.plexSelectType('label="Estado"', 'ANULADA');
-    cy.wait('@solicitudes');
-    cy.wait('@solicitudes').then((xhr) => {
-        expect(xhr.status).to.be.eq(200);
-        const i = xhr.response.body[0].solicitud.historial.length - 1;
-        expect(xhr.response.body[0].solicitud.historial[i].descripcion).to.be.eq('Anulada');
-        expect(xhr.response.body[0].solicitud.historial[i].observaciones).to.be.eq('Una observacion anular');
-    }); 
 
-}
+    it('anular', () => {
+        cy.plexButtonIcon('delete').click();
+        cy.get('textarea').last().type('Una observacion anular', { force: true });
+        cy.plexButton('Confirmar').click();
+        cy.wait('@anularSolicitud').then((xhr) => {
+            expect(xhr.status).to.be.eq(200);
+            const i = xhr.response.body.solicitud.historial.length - 1;
+            expect(xhr.response.body.solicitud.historial[i].observaciones).to.be.eq('Una observacion anular');  
+            expect(xhr.response.body.solicitud.historial[i].accion).to.be.eq('anulada');
+            expect(xhr.response.body.solicitud.historial[i].descripcion).to.be.eq('Anulada');
+        });
+        cy.wait('@solicitudes');
+        cy.plexButtonIcon('chevron-down').click();
+        cy.plexSelectType('label="Estado"', 'ANULADA');
+        cy.wait('@solicitudes').then((xhr) => {
+            expect(xhr.status).to.be.eq(200);
+            const i = xhr.response.body[0].solicitud.historial.length - 1;
+            expect(xhr.response.body[0].solicitud.historial[i].descripcion).to.be.eq('Anulada');
+            expect(xhr.response.body[0].solicitud.historial[i].observaciones).to.be.eq('Una observacion anular');
+        }); 
+    });
+});


### PR DESCRIPTION
### Requerimiento
corregir error en test de anulación

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. El test de anulación tomaba una solicitud pendiente que tenía movimientos en el historial. 
2. Con el cambio en la app no se pueden anular solicitudes con movimientos en el historial.
3. se agrega fixture de solicitud pendiente

