### PR TITLE
EXPORT-HUDS: Test para exportar huds

### DIFF
--- a/cypress/integration/apps/visualizacion-informacion/exportar-huds.spec.ts
+++ b/cypress/integration/apps/visualizacion-informacion/exportar-huds.spec.ts
@@ -1,0 +1,132 @@
+/// <reference types="Cypress" />
+
+context('Exportar HUDS', () => {
+    let token;
+    let pacienteValidado;
+    let pacienteHudsCompleta;
+    let pacienteConPrestacion;
+    before(() => {
+        cy.seed();
+
+        cy.login('30643636', 'asd').then(t => {
+            token = t;
+        });
+        cy.task('database:create:paciente', {
+            template: 'validado'
+        }).then(p => {
+            pacienteValidado = p;
+        });
+        cy.task('database:create:paciente', {
+            template: 'validado'
+        }).then(p => {
+            pacienteHudsCompleta = p;
+        });
+        cy.task('database:create:paciente', {
+            template: 'validado'
+        }).then(p => {
+            pacienteConPrestacion = p;
+        });
+
+    })
+
+    beforeEach(() => {
+        cy.server();
+        cy.goto('/visualizacion-informacion/exportar-huds', token);
+        cy.route('GET', '**/api/core/mpi/pacientes/**').as('getPaciente');
+        cy.route('GET', '**api/core/mpi/pacientes?**').as('busquedaPaciente');
+        cy.route('POST', '**api/modules/huds/export').as('peticionExport');
+        cy.route('GET', '**api/modules/huds/export?**').as('pendientes');
+        cy.route('GET', '**/api/core/tm/tiposPrestaciones**').as('prestaciones');
+
+
+    })
+
+    it('Seleccionar un paciente y solicitar exportar huds entre dos fechas', () => {
+        let ayer = Cypress.moment().add('days', -1).format('DD/MM/YYYY');
+        let hoy = Cypress.moment().format('DD/MM/YYYY');
+        cy.plexText('name="buscador"', pacienteValidado.documento);
+        cy.wait('@busquedaPaciente').then((xhr) => {
+            expect(xhr.status).to.be.eq(200);
+            expect(xhr.response.body[0].apellido).to.be.eq(pacienteValidado.apellido);
+            expect(xhr.response.body[0].nombre).to.be.eq(pacienteValidado.nombre);
+            expect(xhr.response.body[0].documento).to.be.eq(pacienteValidado.documento);
+        });
+        cy.get('paciente-listado plex-item').contains(pacienteValidado.nombre).click();
+        cy.modalPrivacidad('Procesos de Auditoría');
+        cy.wait('@getPaciente').then((xhr) => {
+            expect(xhr.status).to.be.eq(200);
+        });
+        cy.plexDatetime('label="Desde"', ayer);
+        cy.plexDatetime('label="Hasta"', { text: hoy, skipEnter: true });
+        cy.plexButton(' Generar ').click();
+
+        cy.wait('@peticionExport').then((xhr) => {
+            expect(xhr.status).to.be.eq(200);
+        });
+        cy.wait('@pendientes').then((xhr) => {
+            expect(xhr.status).to.be.eq(200);
+            expect(xhr.response.body[0].user.usuario.apellido).to.be.eq("Huenchuman");
+            expect(xhr.response.body[0].user.usuario.nombre).to.be.eq("Natalia");
+            expect(xhr.response.body[0].user.usuario.username).to.be.eq(30643636);
+        })
+        cy.get('plex-list').find('plex-item').contains(pacienteValidado.nombre);
+    });
+
+    it('Seleccionar un paciente y solicitar exportar huds completa', () => {
+        cy.plexText('name="buscador"', pacienteHudsCompleta.documento);
+        cy.wait('@busquedaPaciente').then((xhr) => {
+            expect(xhr.status).to.be.eq(200);
+            expect(xhr.response.body[0].apellido).to.be.eq(pacienteHudsCompleta.apellido);
+            expect(xhr.response.body[0].nombre).to.be.eq(pacienteHudsCompleta.nombre);
+            expect(xhr.response.body[0].documento).to.be.eq(pacienteHudsCompleta.documento);
+        });
+        cy.get('paciente-listado plex-item').contains(pacienteHudsCompleta.nombre).click();
+        cy.modalPrivacidad('Procesos de Auditoría');
+        cy.wait('@getPaciente').then((xhr) => {
+            expect(xhr.status).to.be.eq(200);
+        });
+        cy.plexBool("label='HUDS Completa'", true);
+        cy.plexButton(' Generar ').click();
+        cy.wait('@peticionExport').then((xhr) => {
+            expect(xhr.status).to.be.eq(200);
+        });
+        cy.wait('@pendientes').then((xhr) => {
+            expect(xhr.status).to.be.eq(200);
+            expect(xhr.response.body[0].user.usuario.apellido).to.be.eq("Huenchuman");
+            expect(xhr.response.body[0].user.usuario.nombre).to.be.eq("Natalia");
+            expect(xhr.response.body[0].user.usuario.username).to.be.eq(30643636);
+        })
+        cy.get('plex-list').find('plex-item').contains(pacienteHudsCompleta.nombre);
+    });
+
+    it('Seleccionar un paciente y solicitar exportar huds entre dos fechas y con una prestación', () => {
+        let ayer = Cypress.moment().add('days', -1).format('DD/MM/YYYY');
+        let hoy = Cypress.moment().format('DD/MM/YYYY');
+        cy.plexText('name="buscador"', pacienteConPrestacion.documento);
+        cy.wait('@busquedaPaciente').then((xhr) => {
+            expect(xhr.status).to.be.eq(200);
+            expect(xhr.response.body[0].apellido).to.be.eq(pacienteConPrestacion.apellido);
+            expect(xhr.response.body[0].nombre).to.be.eq(pacienteConPrestacion.nombre);
+            expect(xhr.response.body[0].documento).to.be.eq(pacienteConPrestacion.documento);
+        });
+        cy.get('paciente-listado plex-item').contains(pacienteConPrestacion.nombre).click();
+        cy.modalPrivacidad('Procesos de Auditoría');
+        cy.wait('@getPaciente').then((xhr) => {
+            expect(xhr.status).to.be.eq(200);
+        });
+        cy.plexDatetime('label="Desde"', ayer);
+        cy.plexDatetime('label="Hasta"', { text: hoy, skipEnter: true });
+        cy.plexSelectAsync('label="Prestaciones"', 'consulta de clinica medica', '@prestaciones', 0);
+        cy.plexButton(' Generar ').click();
+        cy.wait('@peticionExport').then((xhr) => {
+            expect(xhr.status).to.be.eq(200);
+        });
+        cy.wait('@pendientes').then((xhr) => {
+            expect(xhr.status).to.be.eq(200);
+            expect(xhr.response.body[0].user.usuario.apellido).to.be.eq("Huenchuman");
+            expect(xhr.response.body[0].user.usuario.nombre).to.be.eq("Natalia");
+            expect(xhr.response.body[0].user.usuario.username).to.be.eq(30643636);
+        })
+        cy.get('plex-list').find('plex-item').contains(pacienteConPrestacion.nombre);
+    });
+})

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -190,7 +190,7 @@ declare namespace Cypress {
         /**
          * Plex DateTime
          */
-        plexDatetime(label: string, texto?: string): Chainable<Element>;
+        plexDatetime(label: string, data?: string | { text?: string, clear?: Boolean, skipEnter?: Boolean }): Chainable<Element>;
 
         /**
          * Plex Bool

--- a/data/authUsers/authUsers_basic.json
+++ b/data/authUsers/authUsers_basic.json
@@ -50,6 +50,7 @@
                     "rup:tipoPrestacion:598ca8375adc68e2a0c121cc",
                     "internacion:*",
                     "huds:visualizacionHuds",
+                    "huds:exportarHuds",
                     "fa:*",
                     "log:*",
                     "usuarios:*",


### PR DESCRIPTION
### Requerimiento
https://proyectos.andes.gob.ar/browse/PRIV-61

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Se agregan test para realizar la petición de exportar Huds de un paciente con los distintos filtros.
2. Se modifica  en `index.d.ts` la función `plexDateTime `para poder usar `skipEnter` y `clear`.
3. Se agrega permiso` huds:exportarHuds` en la colección `AuthUsers`


### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [x] Si
- [ ] No
