### PR TITLE
SEED-PRESTACIONES: Agrego campo id organización

### DIFF
--- a/cypress/plugins/seed-prestaciones.js
+++ b/cypress/plugins/seed-prestaciones.js
@@ -62,6 +62,7 @@ module.exports.seedPrestacion = async (mongoUri, params) => {
         if (params.organizacion) {
             const OrganizacionDB = await client.db().collection('organizacion');
             const orgData = await OrganizacionDB.findOne({ _id: new ObjectId(params.organizacion) }, { projection: { nombre: 1 } });
+            orgData.id = orgData._id;
             prestacion.solicitud.organizacion = orgData;
             prestacion.ejecucion.organizacion = orgData;
         } else {


### PR DESCRIPTION
### Requerimiento
Fix para test del buscador de turnos y prestaciones.

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Por un nuevo cambio en la búsqueda de las prestaciones fuera de agenda, se agrega el campo id a la organización para que funcionen correctamente los test del buscador.


### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No


