### PR TITLE
Epidemiologia - Fix para test de registro en rup

### DIFF
--- a/cypress/integration/apps/epidemiologia/ficha-epidemiologica.spec.ts
+++ b/cypress/integration/apps/epidemiologia/ficha-epidemiologica.spec.ts
@@ -97,10 +97,8 @@ context('Ficha Epidemiológica', () => {
         cy.plexButton('Registrar ficha').click();
         cy.wait('@registroFicha').then((xhr) => {
             expect(xhr.status).to.be.eq(200);
-        })
- 
+        });
         cy.toast('success', 'Su ficha fue registrada correctamente');
-   
         cy.wait('@getPrestacion').then((xhr) => {
             expect(xhr.status).to.be.eq(200);
         });
@@ -126,7 +124,7 @@ context('Ficha Epidemiológica', () => {
         cy.wait('@getPaciente').then((xhr) => {
             expect(xhr.status).to.be.eq(200);
         });
-
+        cy.toast('success', 'Prestación guardada correctamente');
         cy.plexButton(' Validar consulta de seguimiento de paciente asociado a infección por COVID-19 ').click();
 
         cy.get('button').contains('CONFIRMAR').click();


### PR DESCRIPTION
### Requerimiento
Luego del cambio en la ficha para que esta al ser guardada se registre en rup, el nuevo test falla.

### Funcionalidad desarrollada 
<!-- Describir lo desarrollado, nos sirve para ponerlo después en los cambios de cada versión -->
1. Se oculta el toast que indica que la prestación fue guardada para que se puede hacer click en el botón validar prestación.

### Requiere actualizaciones en la base de datos
<!-- Marca con una X la casilla correcta-->
- [ ] Si
- [x] No
