### PR TITLE
PER - corrección de filtros en modulo perinatal

### DIFF
--- a/cypress/integration/apps/perinatal/control-alertas.spec.ts
+++ b/cypress/integration/apps/perinatal/control-alertas.spec.ts
@@ -99,9 +99,8 @@ context('Perinatal Listado', () => {
     });
 
     it('Paciente con control de embarazo no vencido', () => {
-        cy.plexButtonIcon('bell').click();
-        cy.get('plex-list plex-item').should('length', 1);
-        cy.plexButtonIcon('close').click();
+        let fecha = Cypress.moment().add('days', 1).format('DD/MM/YYYY');
+        cy.get('tbody tr').eq(1).contains(fecha);
     })
 
 })

--- a/cypress/integration/apps/perinatal/listado-pacientes.spec.ts
+++ b/cypress/integration/apps/perinatal/listado-pacientes.spec.ts
@@ -96,6 +96,16 @@ context('Perinatal Listado', () => {
         cy.get('table tbody tr').should('length', 1);
     });
 
+    it('Filtro - Fecha de cita', () => {
+        cy.plexDatetime('name="fechaCita"', '07/07/2021');
+        cy.get('table tbody tr').should('length', 1);
+    });
+
+    it('Filtro - Ultimo control', () => {
+        cy.plexDatetime('name="fechaControl"', '06/07/2021');
+        cy.get('table tbody tr').should('length', 1);
+    });
+
     it('Filtro - Buscar paciente', () => {
         cy.plexText('name="paciente"', '10000000');
         cy.get('table tbody tr').should('length', 2);
@@ -153,7 +163,7 @@ context('Perinatal Listado', () => {
         cy.get('plex-layout-sidebar').plexButton(' Agregar nota ').click();
         cy.get('plex-layout-sidebar').plexTextArea('name="notaText"', 'prueba');
         cy.get('plex-layout-sidebar').plexButton('Guardar').click();
-        cy.toast('success', 'Nota editada con éxito');
+        cy.toast('success', 'Nota agregada con éxito');
         cy.wait('@patchPaciente').then((xhr) => {
             expect(xhr.status).to.be.eq(200);
             expect(xhr.response.body.nota).to.be.eq('prueba');


### PR DESCRIPTION
<!--

PASOS PARA REGISTRAR UN PULL REQUEST
_____________________________________________

1) Escribir el nombre siguiendo estas reglas:
   - Indicar como prefijo el nombre del módulo
   - Si la funcionalidad corresponde a una User Story, el nombre debe coincidir son su título
   - No utilizar la palabra fix ni sus derivados

   Ejemplo: CITAS - Reglas de referencia y contrarreferencia para la carga de solicitudes

2) Seleccionar el proyecto al que pertenece (CITAS, RUP, MPI, ...)
3) Asignar revisores que sean miembros del equipo responsable de revisar el pull request
4) Completar las siguientes secciones:

-->
### Requerimiento
https://proyectos.andes.gob.ar/browse/PER-67

### Funcionalidad desarrollada 
1. Se corrigió el filtro de "Agregar nota a paciente" ya que este mismo cuando se agrega o edita una nota el mensaje que muestra es el mismo para ambos casos cuando debería ser diferente.
2. Se agregaron los filtros "fecha de cita" y "ultimo control" ya que anteriormente no se podían por un problema en las cargas de las fechas.
3. En control-alertas se corrigió el ultimo filtro para controlar que el carnet del paciente no este vencido.

### Requiere actualizaciones en la base de datos
- [ ] Si
- [X] No

<!-- Agregar captura de pantalla, si fuera relevante  -->


<!-- Código relevante 
  ```
  (pegar código aquí)  
  ``` 
-->
